### PR TITLE
Clarifying Unknown status from CDNs

### DIFF
--- a/CachePurgeLibrary/RequestModels/IRequestInfo.cs
+++ b/CachePurgeLibrary/RequestModels/IRequestInfo.cs
@@ -16,6 +16,7 @@ namespace CachePurgeLibrary
     {
         Error,
         Unauthorized,
+        Forbidden,
         Throttled,
         Unknown,
         BatchCreated,

--- a/CdnLibrary/src/Utils/CdnPluginHelper.cs
+++ b/CdnLibrary/src/Utils/CdnPluginHelper.cs
@@ -122,6 +122,7 @@ namespace CdnLibrary
                 HttpStatusCode.InternalServerError => RequestStatus.Error,
                 HttpStatusCode.TooManyRequests => RequestStatus.Throttled,
                 HttpStatusCode.Unauthorized => RequestStatus.Unauthorized,
+                HttpStatusCode.Forbidden => RequestStatus.Forbidden,
                 _ => RequestStatus.Unknown,
             };
         }

--- a/CdnLibrary/tests/Akamai/AkamaiRequestProcessor_Test.cs
+++ b/CdnLibrary/tests/Akamai/AkamaiRequestProcessor_Test.cs
@@ -70,6 +70,15 @@ namespace CdnLibrary
         }
 
         [TestMethod]
+        public void SendPurgeRequest_Forbidden()
+        {
+            var purgeBody = new StringContent(string.Empty, System.Text.Encoding.UTF8, "application/json");
+            const string id = "12345";
+            var requestInfo = AkamaiRequestProcessor.SendPurgeRequest("https://fakeUri", purgeBody, GetHandler(id, statusCode: HttpStatusCode.Forbidden), logger).Result;
+            Assert.AreEqual(RequestStatus.Forbidden, requestInfo.RequestStatus);
+        }
+
+        [TestMethod]
         public void GetRequestStatusFromResponse_CorrectRequestID()
         {
             var response = @"{

--- a/MultiCdnApi/src/ResponseModels/UserRequestStatusResult.cs
+++ b/MultiCdnApi/src/ResponseModels/UserRequestStatusResult.cs
@@ -6,19 +6,30 @@
 namespace MultiCdnApi
 {
     using System.Collections.Generic;
+    using Azure.Core;
     using CachePurgeLibrary;
+    using CdnLibrary;
     using Microsoft.AspNetCore.Mvc;
 
     public class UserRequestStatusResult : JsonResult
     {
         public UserRequestStatusResult(UserRequest userRequest) : base(new object())
         {
+            var userRequestPluginStatuses = userRequest.PluginStatuses;
+            if (userRequestPluginStatuses.ContainsKey(CDN.Akamai.ToString()))
+            {
+                var status = userRequestPluginStatuses[CDN.Akamai.ToString()];
+                if (status == RequestStatus.Forbidden.ToString())
+                {
+                    userRequestPluginStatuses[CDN.Akamai.ToString()] = "Forbidden; either the partner wasn't setup in Akamai or CachePurge doesn't have permissions to purge its caches (the first option happens more often than the second)";
+                }
+            }
             Value = new UserRequestStatusValue
             {
                 Id = userRequest.id, 
                 NumCompletedPartnerRequests = userRequest.NumCompletedPartnerRequests, 
                 NumTotalPartnerRequests = userRequest.NumTotalPartnerRequests,
-                PluginStatuses = userRequest.PluginStatuses
+                PluginStatuses = userRequestPluginStatuses
             };
         }
     }

--- a/MultiCdnApi/tests/ResponseModels/UserRequestStatusResultTest.cs
+++ b/MultiCdnApi/tests/ResponseModels/UserRequestStatusResultTest.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace MultiCdnApi.ResponseModels
+{
+    using System.Collections.Generic;
+    using CachePurgeLibrary;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class UserRequestStatusResultTest
+    {
+        [TestMethod]
+        public void TestSerialization()
+        {
+            var userRequest =
+                new UserRequest("partnerId", "description", "ticketId", "hostname", new HashSet<string>()) {
+                    PluginStatuses = { ["AFD"] = "Forbidden", ["Akamai"] = "Forbidden" }
+                };
+            var result = new UserRequestStatusResult(userRequest);
+            Assert.IsInstanceOfType(result.Value, typeof(UserRequestStatusValue));
+            Assert.AreEqual(((UserRequestStatusValue)result.Value).PluginStatuses["AFD"], "Forbidden");
+            Assert.AreNotEqual(((UserRequestStatusValue)result.Value).PluginStatuses["Akamai"], "Forbidden");
+            Assert.IsTrue(((UserRequestStatusValue)result.Value).PluginStatuses["Akamai"].StartsWith("Forbidden"));
+        }
+    }
+}


### PR DESCRIPTION
Currently, if the entity is not set up in Akamai, we show an Unknown status. DRIs don't know what to do in this case, so we wanted to add a little bit more clarifying info to the message.